### PR TITLE
Prepares fhicl-cpp-standalone for usage via CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ foreach(PACKAGE_TO_BUILD ${PACKAGES})
     GIT_REPOSITORY https://github.com/luketpickering/${PACKAGE_TO_BUILD}.git
     GIT_TAG FHICLCPP_SUITE_v${FHICLCPP_SUITE_VERSION}
     DEPENDS ${PREVIOUS_PACKAGE}
+    STEP_TARGETS install
     CMAKE_ARGS --preset=default
                -DCMAKE_CXX_STANDARD=17
                -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
@@ -78,7 +79,14 @@ FILE(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/lib)
 # The target that we're going to construct. We can't do this properly because
 # cetlib's overrides will mangle with sensible usage of CPM or FetchContent_MakeAvailable
 add_library(fhicl_cpp_standalone INTERFACE)
-add_dependencies(fhicl_cpp_standalone fhicl-cpp-install)
+
+set(FHICL_CPP_INSTALL_STEP_TARGET fhicl-cpp-install)
+
+if(NOT TARGET ${FHICL_CPP_INSTALL_STEP_TARGET})
+  message(FATAL_ERROR "FHICL_CPP_INSTALL_STEP_TARGET: ${FHICL_CPP_INSTALL_STEP_TARGET} does not exist")
+endif()
+
+add_dependencies(fhicl_cpp_standalone ${FHICL_CPP_INSTALL_STEP_TARGET})
 target_include_directories(fhicl_cpp_standalone INTERFACE 
   $<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/include> 
   $<INSTALL_INTERFACE:include>)
@@ -86,7 +94,7 @@ target_link_directories(fhicl_cpp_standalone INTERFACE
   $<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/lib> 
   $<INSTALL_INTERFACE:lib>)
 target_link_libraries(fhicl_cpp_standalone INTERFACE 
-  -lfhiclcpp -lcetlib_sqlite SQLite::SQLite3 -lcetlib -lhep_concurrency Boost::filesystem TBB::tbb)
+  -lfhiclcpp -lcetlib_except -lcetlib_sqlite SQLite::SQLite3 -lcetlib -lhep_concurrency Boost::filesystem TBB::tbb)
 set_target_properties(fhicl_cpp_standalone PROPERTIES EXPORT_NAME standalone)
 
 add_library(fhiclcpp::standalone ALIAS fhicl_cpp_standalone)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@
 #
 # Required products:
 #
-#   Boost 1.82.0
+#   Boost 1.75
 #   SQLite 3
-#   oneTBB 2021.9.0
+#   oneTBB 2020
 #
 # I used UPS to provide the above, but it could also be achieved by
 # using local installations.
@@ -14,42 +14,110 @@
 # Testing is not included as part of this build as extra packages are
 # required (e.g. Catch2).
 
-cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20.0 FATAL_ERROR)
 
-project(fhicl-cpp-standalone VERSION 4.18.01)
+set(FHICLCPP_SUITE_VERSION 4_18_01)
+string(REPLACE "_" "." FHICLCPP_SUITE_VERSION_DOT ${FHICLCPP_SUITE_VERSION})
+
+project(fhicl_cpp_standalone VERSION ${FHICLCPP_SUITE_VERSION_DOT})
+
+set(CMAKE_CXX_STANDARD 17)
+set(CXX_STANDARD_REQUIRED ON)
+
+#lets use CPM instead of ExternalProject_Add as it plays better with
+#finding existing binary releases.
+# file(
+#   DOWNLOAD
+#   https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.3/CPM.cmake
+#   ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
+#   EXPECTED_HASH SHA256=cc155ce02e7945e7b8967ddfaff0b050e958a723ef7aad3766d368940cb15494
+# )
+# include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
+
+# These are the system default versions on alma9 as of 2023/11/01
+# and seem to work
+find_package(Boost 1.75 COMPONENTS filesystem REQUIRED)
+find_package(SQLite3 3 REQUIRED)
+find_package(TBB 2020 REQUIRED)
+
+
+set(PACKAGES cetlib-except hep-concurrency cetlib fhicl-cpp)
 
 include(ExternalProject)
 
-set(PACKAGES cetmodules cetlib-except hep-concurrency cetlib fhicl-cpp)
-set(FHICLCPP_SUITE_VERSION FHICLCPP_SUITE_v4_18_01)
-list(LENGTH PACKAGES PACKAGES_LEN)
-
-set(TOP_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 ExternalProject_Add(cetmodules
   PREFIX cetmodules
   GIT_REPOSITORY https://github.com/FNALssi/cetmodules.git
   GIT_TAG 3.22.01
-  CMAKE_ARGS -DBUILD_DOCS:BOOL=FALSE -DCMAKE_INSTALL_PREFIX:STRING=${TOP_BUILD_DIR}/cetmodules-install
+  CMAKE_ARGS -DBUILD_DOCS:BOOL=FALSE 
+             -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
 )
-set(PREFIX_PATH "${TOP_BUILD_DIR}/cetmodules-install")
+set(PREVIOUS_PACKAGE cetmodules)
 
-MATH(EXPR MAX_INDEX "${PACKAGES_LEN}-1")
-foreach(I RANGE 1 ${MAX_INDEX})
-  MATH(EXPR J "${I}-1")
-  list(GET PACKAGES ${I} PACKAGE_TO_BUILD)
-  list(GET PACKAGES ${J} DEPENDENCY)
-
+foreach(PACKAGE_TO_BUILD ${PACKAGES})
   ExternalProject_Add(${PACKAGE_TO_BUILD}
     PREFIX ${PACKAGE_TO_BUILD}
-    GIT_REPOSITORY https://github.com/art-framework-suite/${PACKAGE_TO_BUILD}.git
-    GIT_TAG ${FHICLCPP_SUITE_VERSION}
-    DEPENDS ${DEPENDENCY}
-    LIST_SEPARATOR |
+    GIT_REPOSITORY https://github.com/luketpickering/${PACKAGE_TO_BUILD}.git
+    GIT_TAG FHICLCPP_SUITE_v${FHICLCPP_SUITE_VERSION}
+    DEPENDS ${PREVIOUS_PACKAGE}
     CMAKE_ARGS --preset=default
                -DCMAKE_CXX_STANDARD=17
-               -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
+               -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
                -DBUILD_TESTING:BOOL=FALSE
-               -DCMAKE_INSTALL_PREFIX:STRING=${TOP_BUILD_DIR}/${PACKAGE_TO_BUILD}-install
+               -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
   )
-  string(APPEND PREFIX_PATH "|${TOP_BUILD_DIR}/${PACKAGE_TO_BUILD}-install")
+
+  set(PREVIOUS_PACKAGE ${PACKAGE_TO_BUILD})
 endforeach()
+
+#these directories have to exist or the target definition below fails
+#this would all be a lot easier if we could use FetchContent... thanks cet.
+FILE(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include)
+FILE(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/lib)
+
+# The target that we're going to construct. We can't do this properly because
+# cetlib's overrides will mangle with sensible usage of CPM or FetchContent_MakeAvailable
+add_library(fhicl_cpp_standalone INTERFACE)
+add_dependencies(fhicl_cpp_standalone fhicl-cpp-install)
+target_include_directories(fhicl_cpp_standalone INTERFACE 
+  $<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/include> 
+  $<INSTALL_INTERFACE:include>)
+target_link_directories(fhicl_cpp_standalone INTERFACE 
+  $<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/lib> 
+  $<INSTALL_INTERFACE:lib>)
+target_link_libraries(fhicl_cpp_standalone INTERFACE 
+  -lfhiclcpp -lcetlib_sqlite SQLite::SQLite3 -lcetlib -lhep_concurrency Boost::filesystem TBB::tbb)
+set_target_properties(fhicl_cpp_standalone PROPERTIES EXPORT_NAME standalone)
+
+add_library(fhiclcpp::standalone ALIAS fhicl_cpp_standalone)
+
+install(TARGETS fhicl_cpp_standalone
+    EXPORT fhicl_cpp_standalone-targets)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in"
+  "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfig.cmake"
+  INSTALL_DESTINATION cmake
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+install(EXPORT fhicl_cpp_standalone-targets
+        NAMESPACE fhiclcpp::
+        DESTINATION lib/cmake/fhicl_cpp_standalone)
+install(FILES "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfigVersion.cmake"
+              "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfig.cmake"
+        DESTINATION lib/cmake/fhicl_cpp_standalone)
+
+
+if(TESTS_ENABLED)
+  add_executable(testfhiclcppstandalone testfhiclcppstandalone.cxx)
+  target_link_libraries(testfhiclcppstandalone fhiclcpp::standalone)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ project(fhicl_cpp_standalone VERSION ${FHICLCPP_SUITE_VERSION_DOT})
 set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 
+#Changes default install path to be a subdirectory of the build dir.
+#Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
+if(CMAKE_INSTALL_PREFIX STREQUAL "" OR CMAKE_INSTALL_PREFIX STREQUAL
+  "/usr/local")
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/${CMAKE_SYSTEM_NAME}")
+elseif(NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/${CMAKE_SYSTEM_NAME}")
+endif()
+
 #lets use CPM instead of ExternalProject_Add as it plays better with
 #finding existing binary releases.
 # file(
@@ -122,6 +131,10 @@ install(EXPORT fhicl_cpp_standalone-targets
 install(FILES "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfigVersion.cmake"
               "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfig.cmake"
         DESTINATION lib/cmake/fhicl_cpp_standalone)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/Templates/setup.fhicl_cpp_standalone.sh.in 
+  ${PROJECT_BINARY_DIR}/setup.fhicl_cpp_standalone.sh @ONLY)
+install(PROGRAMS ${PROJECT_BINARY_DIR}/setup.fhicl_cpp_standalone.sh DESTINATION bin)
+
 
 
 if(TESTS_ENABLED)

--- a/README.md
+++ b/README.md
@@ -19,13 +19,71 @@ $ make [-j <n>]
 
 Before invoking `cmake` you must have:
 
-- CMake 3.18 or newer
+- CMake 3.21 or newer (see [here](#fetch-cmake-3-21))
 - A compiler that supports C++17
 - A reasonably modern version of Boost
 - oneTBB
 - SQLite 3
 
 Depending on where these packages are installed, you may need to adjust the `cmake` command line to instruct CMake as to where it can find those packages.
+
+## Using fhicl-cpp-standalone in your own project
+
+Add the following cmake code to pull in and construct the `fhiclcpp::fhiclcpp` CMake target that
+you can link against.
+
+```
+# Uncomment if you aren't already using CPM in your project
+# file(
+#   DOWNLOAD
+#   https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.3/CPM.cmake
+#   ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
+#   EXPECTED_HASH SHA256=cc155ce02e7945e7b8967ddfaff0b050e958a723ef7aad3766d368940cb15494
+# )
+# include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
+CPMFindPackage(
+    NAME fhicl_cpp_standalone
+    GIT_TAG develop
+    VERSION 4.18.01
+    GITHUB_REPOSITORY luketpickering/fhicl-cpp-standalone
+)
+
+target_link_libraries(mytarget PRIVATE fhiclcpp::standalone)
+```
+
+Alternatively if you want to use a binary release/build of fhicl-cpp-standalone,
+make sure that `fhicl_cpp_standalone_ROOT` points to the installation prefix of a release of
+this package, and then use the same CMake as above. If you see something like:
+
+```
+-- fhicl-cpp-standalone Found:
+-- --  fhicl_cpp_standalone_INCLUDE_DIR: /root/software/fhicl-cpp-standalone/build/Linux/include
+-- --      fhicl_cpp_standalone_BIN_DIR: /root/software/fhicl-cpp-standalone/build/Linux/bin
+-- --      fhicl_cpp_standalone_LIB_DIR: /root/software/fhicl-cpp-standalone/build/Linux/lib
+-- --      fhicl_cpp_standalone_VERSION: 4.18.01
+-- CPM: using local package fhicl_cpp_standalone@4.18.01
+```
+
+then you will know it has picked up the 'local' install of fhiclcpp and not
+pulled down a new version of the repo (also the build of your dependent package
+wont need to build all of these dependencies).
+
+### Fetch CMake 3.21
+
+If you just want a local build of cmake for this package and do not want to update
+your system cmake, you can try the below recipe.
+
+```
+CMAKEVERSION=3.21.7
+cd /path/to/repo
+wget https://github.com/Kitware/CMake/archive/refs/tags/v${CMAKEVERSION}.tar.gz
+tar -zxf v${CMAKEVERSION}.tar.gz
+cd CMake-${CMAKEVERSION}
+./bootstrap
+make -j 8
+export PATH=$(pwd)/bin:${PATH}
+which cmake; cmake --version
+```
 
 ## Caveats
 

--- a/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in
+++ b/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in
@@ -1,0 +1,50 @@
+@PACKAGE_INIT@
+
+set(fhicl_cpp_standalone_VERSION @PROJECT_VERSION@)
+
+find_dependency(Boost 1.75 COMPONENTS filesystem REQUIRED)
+find_dependency(SQLite3 3 REQUIRED)
+find_dependency(TBB 2020 REQUIRED)
+
+include(${CMAKE_CURRENT_LIST_DIR}/fhicl_cpp_standalone-targets.cmake)
+
+set(fhicl_cpp_standalone_FOUND TRUE)
+
+if(NOT TARGET fhiclcpp::standalone)
+  message(WARNING "Expected to find target fhiclcpp::standalone in ${CMAKE_CURRENT_LIST_DIR}/fhicl_cpp_standalone-targets.cmake")
+  set(fhicl_cpp_standalone_FOUND FALSE)
+  return()
+endif()
+
+get_filename_component(fhicl_cpp_standalone_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+#possibly a bit redundant, but make sure that we can find a random smattering of dependent libraries
+#that we can't set up in a modern CMake way consistently with including this wrapper package via CPM
+find_path(fhicl_cpp_standalone_INCLUDE_DIR
+  NAMES fhiclcpp/ParameterSet.h
+  PATHS ${fhicl_cpp_standalone_CMAKE_DIR}/../../../include
+)
+find_path(fhicl_cpp_standalone_BIN_DIR
+  NAMES fhicl-dump
+  PATHS ${fhicl_cpp_standalone_CMAKE_DIR}/../../../bin
+)
+find_path(fhicl_cpp_standalone_LIB_DIR
+  NAMES libfhiclcpp.so
+  PATHS ${fhicl_cpp_standalone_CMAKE_DIR}/../../../lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(fhicl_cpp_standalone
+  REQUIRED_VARS 
+    fhicl_cpp_standalone_INCLUDE_DIR 
+    fhicl_cpp_standalone_BIN_DIR
+    fhicl_cpp_standalone_LIB_DIR
+  VERSION_VAR
+    fhicl_cpp_standalone_VERSION
+)
+
+message(STATUS "fhicl-cpp-standalone Found:")
+message(STATUS "--  fhicl_cpp_standalone_INCLUDE_DIR: ${fhicl_cpp_standalone_INCLUDE_DIR}")
+message(STATUS "--      fhicl_cpp_standalone_BIN_DIR: ${fhicl_cpp_standalone_BIN_DIR}")
+message(STATUS "--      fhicl_cpp_standalone_LIB_DIR: ${fhicl_cpp_standalone_LIB_DIR}")
+message(STATUS "--      fhicl_cpp_standalone_VERSION: ${fhicl_cpp_standalone_VERSION}")

--- a/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in
+++ b/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in
@@ -2,6 +2,8 @@
 
 set(fhicl_cpp_standalone_VERSION @PROJECT_VERSION@)
 
+include(CMakeFindDependencyMacro)
+
 find_dependency(Boost 1.75 COMPONENTS filesystem REQUIRED)
 find_dependency(SQLite3 3 REQUIRED)
 find_dependency(TBB 2020 REQUIRED)

--- a/cmake/Templates/setup.fhicl_cpp_standalone.sh.in
+++ b/cmake/Templates/setup.fhicl_cpp_standalone.sh.in
@@ -1,0 +1,60 @@
+if [ ${BASH_VERSINFO[0]} -le 2 ]; then
+  echo "[ERROR]: You must source this setup script (not run it in a sub-shell). Use like $ source setup.sh"
+  exit 1
+fi
+
+if ! type add_to_PATH &> /dev/null; then
+
+### Adapted from https://unix.stackexchange.com/questions/4965/keep-duplicates-out-of-path-on-source
+function add_to_PATH () {
+  for d; do
+
+    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
+    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+
+    if [ "$d" == "/usr/bin" ] || [ "$d" == "/usr/bin64" ] || [ "$d" == "/usr/local/bin" ] || [ "$d" == "/usr/local/bin64" ]; then
+      case ":$PATH:" in
+        *":$d:"*) :;;
+        *) export PATH=$PATH:$d;;
+      esac
+    else
+      case ":$PATH:" in
+        *":$d:"*) :;;
+        *) export PATH=$d:$PATH;;
+      esac
+    fi
+  done
+}
+
+fi
+
+if ! type add_to_LD_LIBRARY_PATH &> /dev/null; then
+
+function add_to_LD_LIBRARY_PATH () {
+  for d; do
+
+    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
+    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+
+    if [ "$d" == "/usr/lib" ] || [ "$d" == "/usr/lib64" ] || [ "$d" == "/usr/local/lib" ] || [ "$d" == "/usr/local/lib64" ]; then
+      case ":$LD_LIBRARY_PATH:" in
+        *":$d:"*) :;;
+        *) export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d;;
+      esac
+    else
+      case ":$LD_LIBRARY_PATH:" in
+        *":$d:"*) :;;
+        *) export LD_LIBRARY_PATH=$d:$LD_LIBRARY_PATH;;
+      esac
+    fi
+  done
+}
+
+fi
+
+export fhicl_cpp_standalone_ROOT=@CMAKE_INSTALL_PREFIX@
+export fhicl_cpp_standalone_VERSION=@PROJECT_VERSION@
+
+add_to_PATH "@CMAKE_INSTALL_PREFIX@/bin"
+
+add_to_LD_LIBRARY_PATH "@CMAKE_INSTALL_PREFIX@/lib"

--- a/testfhiclcppstandalone.cxx
+++ b/testfhiclcppstandalone.cxx
@@ -1,0 +1,9 @@
+#include "fhiclcpp/ParameterSet.h"
+
+int main(int argc, char const *argv[]) {
+  std::unique_ptr<cet::filepath_maker> fm =
+      std::make_unique<cet::filepath_maker>();
+
+  fhicl::ParameterSet in_ps = fhicl::ParameterSet::make(argv[1], *fm);
+  std::cout << in_ps.to_indented_string() << std::endl;
+}


### PR DESCRIPTION
Tweaks the buildsystem for this package to be easier to include automatically in other packages buildsystems via CPM.

If this package is built and installed, it will now install a meta fhicl_cpp_standaloneConfig.cmake which can be used with find_package for CPMFindPackage to set up the fhiclcpp::standalone CMake target.